### PR TITLE
Fix the URL and message on docker build summary.

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -92,9 +92,9 @@ jobs:
             Your image has been successfully uploaded to the remote repository. Please see the details below.
 
             **Tag:** ${{ steps.vars.outputs.IMAGE_TAG }}
-            **URL:** ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ steps.vars.outputs.IMAGE_TAG }}
+            **URL:** ${{ steps.login-ecr.outputs.registry }}/${{ secrets.AWS_ECR_REPOSITORY }}:${{ steps.vars.outputs.IMAGE_TAG }}
             **AWS Respository URL:** [${{ steps.vars.outputs.IMAGE_TAG }}](
-              https://${{ secrets.AWS_REGION}}.console.aws.amazon.com/ecr/repositories/private/${{ steps.configure_aws_credentials.outputs.aws-account-id}}/${{ github.event.repository.name }}/_/image/${{ steps.build_tag_docker_image.outputs.SHA }}/details?region=${{ secrets.AWS_REGION}}
+              https://${{ secrets.AWS_REGION}}.console.aws.amazon.com/ecr/repositories/private/${{ steps.configure_aws_credentials.outputs.aws-account-id}}/${{ secrets.AWS_ECR_REPOSITORY }}/_/image/${{ steps.build_tag_docker_image.outputs.SHA }}/details?region=${{ secrets.AWS_REGION}}
             )
           comment_tag: docker_image_tag
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #12 

## Summary
- The message insert in the PR by the CI `build_docker_image` use the wrong variable as a repository and it makes the message come with a wrong docker image URL.

## Checklist
- [X] Signed all commits for DCO
- [ ] ~Added tests~
- [ ] ~Updated documentation (as needed)~
- [ ] ~Updated migration guide (as needed)~
- [ ] ~Consider updating Python bindings (if it affects the public API)~

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸