### PR TITLE
Use the right app names on CI

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -22,5 +22,6 @@ jobs:
     uses: ./.github/workflows/remove_robomaker_simulations.yml
     secrets:
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+      AWS_ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/remove_robomaker_simulations.yml
+++ b/.github/workflows/remove_robomaker_simulations.yml
@@ -6,6 +6,8 @@ on:
     secrets:
       AWS_ACCESS_KEY:
         required: true
+      AWS_ECR_REPOSITORY:
+        required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
       AWS_REGION:
@@ -35,7 +37,7 @@ jobs:
 
       - name: Delete Robot, simulation, and simulation of Amazon Robomaker
         env:
-          ROBOT_APPLICATION_ID: ${{ github.event.repository.name }}-PR-${{ github.event.number }}
-          SIMULATION_APPLICATION_ID: ${{ github.event.repository.name }}-PR-${{ github.event.number }}
+          ROBOT_APPLICATION_ID: ${{ secrets.AWS_ECR_REPOSITORY }}-PR-${{ github.event.number }}
+          SIMULATION_APPLICATION_ID: ${{ secrets.AWS_ECR_REPOSITORY }}-PR-${{ github.event.number }}
         run: |
           python3 ekumen_cloud_robotics_ci/scripts/delete_simulation_job.py $ROBOT_APPLICATION_ID $SIMULATION_APPLICATION_ID


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #13 

## Summary
- `.github/workflows/remove_robomaker_simulations.yml` is using the wrong repository name. Those changes use a secret with the right repository name.

## Checklist
- [X] Signed all commits for DCO
- [ ] ~Added tests~
- [ ] ~Updated documentation (as needed)~
- [ ] ~Updated migration guide (as needed)~
- [ ] ~Consider updating Python bindings (if it affects the public API)~

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸