### PR TITLE
Add timeout to steps in the pipeline.

### DIFF
--- a/.github/workflows/remove_docker_images.yml
+++ b/.github/workflows/remove_docker_images.yml
@@ -17,6 +17,7 @@ jobs:
   remove_docker_image:
     runs-on: ubuntu-22.04
     name: Remove AWS Robomaker resources
+    timeout-minutes: 1
 
     steps:
       - name: Checkout

--- a/.github/workflows/remove_robomaker_simulations.yml
+++ b/.github/workflows/remove_robomaker_simulations.yml
@@ -15,6 +15,7 @@ jobs:
   remove_robomaker_simulation_jobs:
     runs-on: ubuntu-22.04
     name: Remove robomaker simulations jobs
+    timeout-minutes: 1
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# 🎉 New feature

Closes #7

## Summary
- Just as the title says, we should measure and assign some time as a timeout to each stage to ensure nothing runs forever.

## Test it
- Check the pipelines when the PR is close.

## Checklist
- [X] Signed all commits for DCO
- [ ] ~Added tests~
- [ ] ~Added example and/or tutorial~
- [ ] ~Updated documentation (as needed)~
- [ ] ~Updated migration guide (as needed)~
- [ ] ~Consider updating Python bindings (if it affects the public API)~

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.