### PR TITLE
Add  flag when install rosdep.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,7 +107,7 @@ RUN vcs import --input /home/$USER/ws/src/andino_integration_tests/vcs_config.ya
 RUN sudo apt update \
     && sudo apt upgrade -y \
     && rosdep update \
-    && rosdep install -i -y --rosdistro humble --from-paths src
+    && rosdep install -i -y -r --rosdistro humble --from-paths src
 
 # Compile the workspace, switch terminals (from default /bin/sh) to properly source the environment.
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #20 

## Summary
CI is failing when trying to create a docker image.

## Checklist
- [X] Signed all commits for DCO
- [ ] ~Added tests~
- [ ] ~Updated documentation (as needed)~
- [ ] ~Updated migration guide (as needed)~
- [ ] ~Consider updating Python bindings (if it affects the public API)~

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.